### PR TITLE
Fix JDA Gateway Reconnect Loop and Proxy Configuration

### DIFF
--- a/src/main/java/main/config/BotStart.java
+++ b/src/main/java/main/config/BotStart.java
@@ -1,6 +1,5 @@
 package main.config;
 
-import jakarta.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import main.controller.UpdateController;
@@ -29,10 +28,11 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -42,10 +42,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-@Configuration
+@Component
 @EnableScheduling
 @AllArgsConstructor
-public class BotStart {
+public class BotStart implements CommandLineRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BotStart.class.getName());
 
@@ -57,7 +57,6 @@ public class BotStart {
 
     @Getter
     private static JDA jda;
-    private final JDABuilder jdaBuilder = JDABuilder.createDefault(Config.getTOKEN());
     private static final GiveawayRegistry instance = GiveawayRegistry.getInstance();
 
     //REPOSITORY
@@ -73,13 +72,27 @@ public class BotStart {
     private final SaveUsersService saveUsersService;
     private final CoreBot coreBot;
 
-    @PostConstruct
+    @Override
+    public void run(String... args) {
+        startBot();
+    }
+
     public void startBot() {
         try {
             //Устанавливаем языки
             setLanguages();
             getLocalizationFromDB();
             getUserZoneIdFromDB();
+
+            if (Config.IS_PROXY) {
+                LOGGER.info("Setting system SOCKS proxy: {}:10808", Config.PROXY_IP);
+                System.setProperty("socksProxyHost", Config.PROXY_IP);
+                System.setProperty("socksProxyPort", "10808");
+                // Avoid proxying local connections (like MariaDB if it's on localhost or in the same docker network by name)
+                System.setProperty("http.nonProxyHosts", "localhost|127.0.0.1|mariadb|database");
+            }
+
+            JDABuilder jdaBuilder = JDABuilder.createDefault(Config.getTOKEN());
 
             List<GatewayIntent> intents = Arrays.asList(
                     GatewayIntent.GUILD_MEMBERS,
@@ -107,11 +120,6 @@ public class BotStart {
             jdaBuilder.setActivity(Activity.playing("Starting..."));
             jdaBuilder.setBulkDeleteSplittingEnabled(false);
             jdaBuilder.addEventListeners(coreBot);
-
-            if (Config.IS_PROXY) {
-                System.setProperty("socksProxyHost", Config.PROXY_IP);
-                System.setProperty("socksProxyPort", "10808");
-            }
 
             jda = jdaBuilder.build();
             jda.awaitReady();
@@ -141,6 +149,7 @@ public class BotStart {
     }
 
     public static void updateActivity() {
+        if (BotStart.jda == null) return;
         if (!Config.isIsDev()) {
             int serverCount = BotStart.jda.getGuilds().size();
             BotStart.jda.getPresence().setActivity(Activity.playing(BotStart.activity + serverCount + " guilds"));
@@ -152,6 +161,7 @@ public class BotStart {
     @Scheduled(fixedDelay = 5, initialDelay = 1, timeUnit = TimeUnit.SECONDS)
     private void schStartGiveaway() {
         try {
+            if (jda == null) return;
             scheduleStartService.scheduleStart(updateController, jda);
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/src/main/java/main/core/events/ReactionEvent.java
+++ b/src/main/java/main/core/events/ReactionEvent.java
@@ -25,8 +25,17 @@ public class ReactionEvent {
     private static final JSONParsers jsonParsers = new JSONParsers();
 
     public void reaction(@NotNull MessageReactionAddEvent event, UpdateController updateController) {
+        User user = event.getUser();
+        if (user == null) {
+            event.retrieveUser().queue(u -> handleReaction(event, u, updateController),
+                    e -> LOGGER.error("Failed to retrieve user for reaction event", e));
+        } else {
+            handleReaction(event, user, updateController);
+        }
+    }
+
+    private void handleReaction(@NotNull MessageReactionAddEvent event, User user, UpdateController updateController) {
         try {
-            User user = event.retrieveUser().complete();
             Member member = event.getMember();
 
             if (member == null || user.isBot()) return;
@@ -51,7 +60,7 @@ public class ReactionEvent {
                         Role roleById = event.getGuild().getRoleById(roleId);
                         boolean isForSpecificRole = giveawayData.isForSpecificRole();
 
-                        if (isForSpecificRole && !event.getMember().getRoles().contains(roleById)) {
+                        if (isForSpecificRole && !member.getRoles().contains(roleById)) {
                             String url = GiveawayUtils.getDiscordUrlMessage(guildIdLong, event.getGuildChannel().getIdLong(), messageId);
                             LOGGER.info("Нажал на эмодзи, но у него нет доступа к розыгрышу: {}", user.getId());
                             //Получаем ссылку на Giveaway


### PR DESCRIPTION
This PR addresses the issue where the Discord bot would successfully login but disconnect with code 1000 after 60-120 seconds. 

The root causes identified and fixed are:
1. Blocking the JDA event thread: Using `.complete()` in the reaction listener could block heartbeats, leading to gateway disconnection.
2. Initialization timing: Setting SOCKS proxy properties after creating JDABuilder (due to field initialization) meant the underlying HTTP client might not pick them up correctly.
3. Spring lifecycle: Blocking the main thread with `jda.awaitReady()` during context refresh can cause issues in containerized environments.

Changes:
- Modified `ReactionEvent.java` to use `.queue()`.
- Refactored `BotStart.java` to implement `CommandLineRunner`, move initialization logic, and improve proxy settings.
- Added defensive null checks for the JDA instance in `@Scheduled` methods.

---
*PR created automatically by Jules for task [17434482650336209646](https://jules.google.com/task/17434482650336209646) started by @megoRU*